### PR TITLE
Fix cursor visibility on iOS

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -130,6 +130,12 @@
 .orgmode-view .cm-line.cm-line {
   caret-color: var(--caret-color) !important;
 }
+.orgmode-view .cm-content {
+  caret-color: var(--caret-color) !important;
+}
+.orgmode-view .cm-cursor {
+  border-left-color: var(--caret-color) !important;
+}
 
 .theme-dark .orgmode-view .cm-fat-cursor {
   background-color: var(--text-accent) !important;


### PR DESCRIPTION
## Summary

Fixes the orgmode editor cursor being invisible on iOS Obsidian by explicitly applying the caret color to the CodeMirror content element and cursor border.

## Root cause

The existing stylesheet set `caret-color` on `.cm-line`, but on iOS Obsidian the editable CodeMirror content/native caret path can still end up with an invisible caret. Applying the caret color directly to `.cm-content` keeps the native caret visible, and applying it to `.cm-cursor` keeps the CodeMirror cursor consistent.

## Validation

- Reproduced the invisible cursor on iOS Obsidian before the change.
- Confirmed the cursor becomes visible on iOS Obsidian after the change.
- Ran `npm test` successfully: 51 tests passed.

## ScreenShot

### before
<img width="603" height="1311" alt="IMG_1775" src="https://github.com/user-attachments/assets/3c5331cf-a7d7-4c2a-a387-7af7a3bfe9a3" />

### after
<img width="603" height="1311" alt="IMG_1778" src="https://github.com/user-attachments/assets/4d41e906-e6b5-41ac-baea-ec85a021d3e7" />

